### PR TITLE
Remove a local striplog import

### DIFF
--- a/tests/test_io/test_welly_to_subsurface.py
+++ b/tests/test_io/test_welly_to_subsurface.py
@@ -19,8 +19,7 @@ welly = pytest.importorskip('welly')
 
 pf = pathlib.Path(__file__).parent.absolute()
 data_path = pf.joinpath('../data/borehole/')
-import sys
-sys.path.insert(0, '../../../striplog_miguel/striplog/')
+
 from striplog import Striplog, Component
 
 


### PR DESCRIPTION
Updated `test_welly_to_subsurface.py` to remove a local import from @Leguark Striplog fork.